### PR TITLE
Serve multiple services w/o race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - The default site title is now _\<Service Name\> - Swagger UI_ (instead of just _Swagger UI_)
 - REST services are now available as well in the Swagger UI.  Previously, only OData services were allowed.  This was to avoid potential issues as the underlying OpenAPI transformation uses OData as intermediate protocol.  So, as long as we don't see issues, allow REST services as well.
 
+### Fixed
+
+- Multiple services are now properly served, w/o the previous stale content of `swagger-ui-init.js`.  Requires `swagger-ui-express` >= 4.6.2
+
 ## Version 0.5.0 - 2022-06-09
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = (options={}, swaggerUiOptions={}) => {
     router.use(mount, (req, _, next) => {
       req.swaggerDoc = toOpenApiDoc(service, options)
       next()
-    }, swaggerUi.serve, swaggerUi.setup(null, uiOptions))
+    }, swaggerUi.serveFiles(), swaggerUi.setup(null, uiOptions))
+
     addLinkToIndexHtml(service, apiPath)
   })
   return router

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@sap/cds-dk": ">=4.9",
-    "swagger-ui-express": "^4"
+    "swagger-ui-express": "^4.6.2"
   },
   "peerDependencies": {
     "@sap/cds": ">=5",

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -21,4 +21,12 @@ describe('Swagger UI', ()=>{
     expect (data) .match (/Show in Swagger UI/i)
   })
 
+  test('multiple services', async()=>{
+    let data  = (await GET `/$api-docs/browse/swagger-ui-init.js`).data
+    expect (data ) .to.be.a('string').that.contains('CatalogService')
+
+    data  = (await GET `/$api-docs/admin/swagger-ui-init.js`).data
+    expect (data ) .to.be.a('string').that.contains('AdminService')
+  })
+
 })


### PR DESCRIPTION
Use swagger-ui-express's `serveFiles` instead of `serve` for this.
Otherwise requests for different services will yield the same
`swagger-ui-init.js` (with the wrong swagger spec).

Requires https://github.com/scottie1984/swagger-ui-express/pull/336
Fixes https://github.com/chgeo/cds-swagger-ui-express/issues/48