### PR TITLE
feat: add OData Version to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Use Swagger UI 5
 - Drop Node 14 support
 
+### Added
+
+- New option `odataVersion` to specify the OData version used to compile the OpenAPI specs
+
 ### Fixed
 
 - Works with `@sap/cds` 7.4 again

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Call `cds_swagger ({...})` with the following object as first parameter:
 {
   "basePath": "/$api-docs", // the root path to mount the middleware on
   "apiPath": "", // the root path for the services (useful if behind a reverse proxy)
-  "diagram": true // whether to render the YUML diagram
+  "diagram": true, // whether to render the YUML diagram
+  "odataVersion": "4.0" // specify the OData Version used by cds-dk (>=7.2.0) to compile the OpenAPI specs. When undefined, this defaults to 4.01
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -59,4 +59,5 @@ function addLinkToIndexHtml (service, apiPath) {
  * @property {string} basePath - the root path to mount the middleware on
  * @property {string} apiPath - the root path for the services (useful if behind a reverse proxy)
  * @property {boolean} diagram - whether to render the YUML diagram
+ * @property {string} odataVersion - the OData version used to compile the OpenAPI specs. Defaults to 4.01
  */

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function toOpenApiDoc (service, options = {}) {
   if (!cache[service.name]) {
     cache[service.name] = cds.compile.to.openapi(service.model, {
       service: service.name,
+      'odata-version': options.odataVersion,
       'openapi:url': join('/', options.apiPath, service.path),
       'openapi:diagram': ('diagram' in options ? options.diagram : true)
     })

--- a/tests/server-options.test.js
+++ b/tests/server-options.test.js
@@ -1,7 +1,7 @@
-process.env.TEST_OPTIONS    = JSON.stringify({basePath:'/test-base', apiPath: '/root', diagram:false})
+process.env.TEST_OPTIONS    = JSON.stringify({basePath:'/test-base', apiPath: '/root', diagram:false, odataVersion:'4.0'})
 process.env.TEST_OPTIONS_UI = JSON.stringify({customSiteTitle: 'My Custom Title'})
 
-const cds = require('@sap/cds/lib')
+const cds = require('@sap/cds')
 const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
 
 describe('with options', ()=>{


### PR DESCRIPTION
Hey there,

I found an issue when using @cds-dk version 7.2.0 or later in my project. 
@cds-dk offers the parameter `odata-version` which, if left blank, defaults to '4.01'. However if your OData service is still on version 4.0 (which should be the case for most projects), OData functions would will not be compiled correctly. Odata functions can be called without parentheses in OData version 4.01 but not in 4.0.

This PR adds an the `odataVersion` parameter to the options, so that projects can specify which OData version should be used for the OpenAPI compilation.

Feel free to suggest any changes.

Kind regards,
Yannick