### PR TITLE
Auto registration as CAP plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 0.8.0 - tbd
 
-### Changed
+### Added
+
+- Auto-registration mode: the middleware registers itself when loaded as a CAP plugin
+- Declarative configuration through `package.json` / `cds-rc.json`
+- Programmatic registration is still possible, but disables auto mode then
 
 ## Version 0.7.0 - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Declarative configuration through `package.json` / `cds-rc.json`
 - Programmatic registration is still possible, but disables auto mode then
 
+### Changed
+
+- Make dependency to `@sap/cds-dk` optional.  If running with the `cds` executable during development, the dependency is fulfilled anyways. Only when running as part of a deployed app with `cds-serve`, then such a dependency is needed.
+
 ## Version 0.7.0 - 2023-12-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,48 +1,76 @@
 # cds-swagger-ui-express
 
-An express middleware to serve OpenAPI definitions for [CAP](https://cap.cloud.sap) services in Swagger UI.
+An CAP plugin to serve OpenAPI definitions for [CAP](https://cap.cloud.sap) services in Swagger UI.
 Builds on top of [swagger-ui-express](https://www.npmjs.com/package/swagger-ui-express).
 
 ![Preview](https://raw.githubusercontent.com/chgeo/cds-swagger-ui-express/main/assets/cds-swagger-ui.png)
 
-## Installation
+## Setup
 
-In your project, execute
+In your project, just add a dependency like so:
 ```sh
-npm install --save-dev cds-swagger-ui-express
+npm add --save-dev cds-swagger-ui-express
 ```
 
-## Usage
+Once loaded by CAP, the package registers itself as a middleware with a default configuration.
 
-Have this in your [`server.js`](https://cap.cloud.sap/docs/node.js/cds-server#custom-server-js):
+## Run
 
-```js
-const cds = require ('@sap/cds')
-module.exports = cds.server
+After starting the app with `cds watch` or so, Swagger UI is served at `/$api-docs/<service-path>`, like http://localhost:4004/$api-docs/browse/
 
-if (process.env.NODE_ENV !== 'production') {
-  const cds_swagger = require ('cds-swagger-ui-express')
-  cds.on ('bootstrap', app => app.use (cds_swagger()) )
+## Configuration
+
+You can set the most prominent options in `package.json` or `cds-rc.json`, as in other CAP apps:
+```jsonc
+"cds": {
+  "swagger": {
+    "basePath": "/$api-docs", // the root path to mount the middleware on
+    "apiPath": "", // the root path for the services (useful if behind a reverse proxy)
+    "diagram": true, // whether to render the YUML diagram
+    "odataVersion": "4.0" // the OData Version to compile the OpenAPI specs. Defaults to 4.01
+  }
 }
 ```
 
-Swagger UI is then served on `/$api-docs/<service-path>`, like http://localhost:4004/$api-docs/browse/
+To disable the plugin, set this:
+```jsonc
+"cds": {
+  "swagger": false
+}
+```
 
-## Configuration
+Note that you can also set environment variables for each option, like `CDS_SWAGGER=false`.  See the [`cds.env` docs](https://cap.cloud.sap/docs/node.js/cds-env#process-env) for more.
+
+
+## Programmatic Usage (advanced)
+
+If you need to register the plugin programmatically, e.g. in certain conditions only, you can do so in your [`server.js`](https://cap.cloud.sap/docs/node.js/cds-server#custom-server-js):
+
+```js
+const cds = require ('@sap/cds')
+const cds_swagger = require ('cds-swagger-ui-express')
+cds.on ('bootstrap', app =>
+  app.use (cds_swagger ())
+)
+```
+
+In this case, the default 'auto registration' as plugin is disabled automatically to avoid conflicts.
+
+### Programmatic Configuration
+
+If the middleware is registered programmatically, you need to pass in the options through the API as well. No configuration from `package.json` is used here.
 
 Call `cds_swagger ({...})` with the following object as first parameter:
 ```jsonc
 {
-  "basePath": "/$api-docs", // the root path to mount the middleware on
-  "apiPath": "", // the root path for the services (useful if behind a reverse proxy)
-  "diagram": true, // whether to render the YUML diagram
-  "odataVersion": "4.0" // the OData Version to compile the OpenAPI specs. Defaults to 4.01
+  "basePath": ...,
+  // see section above for more
 }
 ```
 
-## Swagger Configuration
+#### Swagger UI Options
 
-Call `cds_swagger ({...}, {...})` with an additional object as second parameter. This object is passed to `swagger-ui-express` as [custom options](https://www.npmjs.com/package/swagger-ui-express#user-content-custom-swagger-options).
+Call `cds_swagger ({...}, {...})` with an additional object as <em>second</em> parameter. This object is passed to `swagger-ui-express` as [custom options](https://www.npmjs.com/package/swagger-ui-express#user-content-custom-swagger-options).
 
 Example:
 
@@ -61,7 +89,3 @@ For questions to specific properties, contact the maintainers of [swagger-ui-exp
 ### Notes
 
 If you call [`cds.serve`](https://cap.cloud.sap/docs/node.js/cds-serve#cds-serve) on your own in your `server.js`, make sure to install this middleware _before_, as it relies on CDS' [`serving` events](https://cap.cloud.sap/docs/node.js/cds-server#cdson--serving-service).
-
-### Known Issues
-
-None at this time.

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,0 +1,19 @@
+const cds = require ('@sap/cds')
+const DEBUG = cds.debug('swagger')
+const { registered } = require ('./lib/etc')
+
+cds.on ('bootstrap', app => {
+  const { swagger } = cds.env
+  if (!swagger)  {
+    return DEBUG?.('Plugin disabled by configuration')
+  }
+
+  if (cds[registered]) {
+    return DEBUG?.('Plugin disabled: already registered programmatically')
+  }
+
+  DEBUG?.('Plugin with options', swagger)
+  const cds_swagger = require('./lib/middleware')
+  app.use(cds_swagger(swagger))
+
+})

--- a/index.js
+++ b/index.js
@@ -1,63 +1,10 @@
-const cds = require('@sap/cds-dk')
-const swaggerUi = require('swagger-ui-express')
-const express = require('express')
-const { join } = require('path')
-const LOG = cds.log('swagger')
+const cds = require ('@sap/cds')
+const DEBUG = cds.debug('swagger')
 
+DEBUG?.('Programmatic registration')
+const { registered } = require ('./lib/etc')
+cds[registered] = true
 
-/**
- * Creates express middleware to serve CDS services in the Swagger UI
- *
- * @param {CdsSwaggerOptions} options - options for cds-swagger-ui itself
- * @param {swaggerUi.SwaggerUiOptions} swaggerUiOptions - options passed to swagger-ui-express
- * @returns {express.RequestHandler} - an express middleware
- */
-module.exports = (options={}, swaggerUiOptions={}) => {
-  options = Object.assign({ basePath: '/$api-docs', apiPath: '' }, options)
-  const router = express.Router()
+module.exports = require('./lib/middleware')
 
-  cds.on('serving', service => {
-    const apiPath = options.basePath + service.path
-    const mount = apiPath.replace('$', '[\\$]')
-    LOG._debug && LOG.debug('serving Swagger UI for ', { service: service.name, at: apiPath })
-
-    const uiOptions = Object.assign({ customSiteTitle: `${service.name} - Swagger UI` }, swaggerUiOptions)
-    router.use(mount, (req, _, next) => {
-      req.swaggerDoc = toOpenApiDoc(service, options)
-      next()
-    }, swaggerUi.serveFiles(), swaggerUi.setup(null, uiOptions))
-
-    addLinkToIndexHtml(service, apiPath)
-  })
-  return router
-}
-
-const cache = {}
-function toOpenApiDoc (service, options = {}) {
-  if (!cache[service.name]) {
-    cache[service.name] = cds.compile.to.openapi(service.model, {
-      service: service.name,
-      'odata-version': options.odataVersion,
-      'openapi:url': join('/', options.apiPath, service.path),
-      'openapi:diagram': ('diagram' in options ? options.diagram : true),
-      to: 'openapi' // workaround needed for cds-dk 7.4
-    })
-  }
-  return cache[service.name]
-}
-
-function addLinkToIndexHtml (service, apiPath) {
-  const provider = (entity) => {
-    if (entity) return // avoid link on entity level, looks too messy
-    return { href: apiPath, name: 'Open API Preview', title: 'Show in Swagger UI' }
-  }
-  service.$linkProviders ? service.$linkProviders.push(provider) : service.$linkProviders = [provider]
-}
-
-/**
- * @typedef {Object} CdsSwaggerOptions
- * @property {string} basePath - the root path to mount the middleware on
- * @property {string} apiPath - the root path for the services (useful if behind a reverse proxy)
- * @property {boolean} diagram - whether to render the YUML diagram
- * @property {string} odataVersion - the OData version used to compile the OpenAPI specs. Defaults to 4.01
- */
+// important: this file must not be loaded when running as plugin ('auto' registration mode)

--- a/lib/etc.js
+++ b/lib/etc.js
@@ -1,0 +1,1 @@
+module.exports.registered = Symbol.for('swaggerui_registered')

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,9 +1,9 @@
-const cds = require('@sap/cds-dk')
+const cds = requireCdsOpenAPI()
+const LOG = cds.log('swagger')
+
 const swaggerUi = require('swagger-ui-express')
 const express = require('express')
 const { join } = require('path')
-const LOG = cds.log('swagger')
-
 
 /**
  * Creates express middleware to serve CDS services in the Swagger UI
@@ -53,6 +53,24 @@ function addLinkToIndexHtml (service, apiPath) {
     return { href: apiPath, name: 'Open API Preview', title: 'Show in Swagger UI' }
   }
   service.$linkProviders ? service.$linkProviders.push(provider) : service.$linkProviders = [provider]
+}
+
+/**
+ * Loads the compile.to.openapi function from @sap/cds-dk or throws an error if not installed.
+ * Will get simpler in the future when we have a dedicated openapi plugin.
+ *
+ * @returns { import('@sap/cds-dk') }
+ */
+function requireCdsOpenAPI () {
+  try {
+    return require('@sap/cds-dk')
+  } catch (err) {
+    const cds = require('@sap/cds')
+    if (!cds.compile.to.openapi) {
+      throw new Error(`'@sap/cds-dk' is not installed. Add it as a (dev) dependency to use this plugin`, { cause: err })
+    }
+    return cds
+  }
 }
 
 /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,64 @@
+const cds = require('@sap/cds-dk')
+const swaggerUi = require('swagger-ui-express')
+const express = require('express')
+const { join } = require('path')
+const LOG = cds.log('swagger')
+
+
+/**
+ * Creates express middleware to serve CDS services in the Swagger UI
+ *
+ * @param {CdsSwaggerOptions} options - options for cds-swagger-ui itself
+ * @param {swaggerUi.SwaggerUiOptions} swaggerUiOptions - options passed to swagger-ui-express
+ * @returns {express.RequestHandler} - an express middleware
+ */
+module.exports = (options={}, swaggerUiOptions={}) => {
+  options = Object.assign({ basePath: '/$api-docs', apiPath: '' }, options)
+
+  const router = express.Router()
+
+  cds.on('serving', service => {
+    const apiPath = options.basePath + service.path
+    const mount = apiPath.replace('$', '[\\$]')
+    LOG._debug && LOG.debug('serving Swagger UI for', { service: service.name, at: apiPath })
+
+    const uiOptions = Object.assign({ customSiteTitle: `${service.name} - Swagger UI` }, swaggerUiOptions)
+    router.use(mount, (req, _, next) => {
+      req.swaggerDoc = toOpenApiDoc(service, options)
+      next()
+    }, swaggerUi.serveFiles(), swaggerUi.setup(null, uiOptions))
+
+    addLinkToIndexHtml(service, apiPath)
+  })
+  return router
+}
+
+const cache = {}
+function toOpenApiDoc (service, options = {}) {
+  if (!cache[service.name]) {
+    cache[service.name] = cds.compile.to.openapi(service.model, {
+      service: service.name,
+      'odata-version': options.odataVersion,
+      'openapi:url': join('/', options.apiPath, service.path),
+      'openapi:diagram': ('diagram' in options ? options.diagram : true),
+      to: 'openapi' // workaround needed for cds-dk 7.4
+    })
+  }
+  return cache[service.name]
+}
+
+function addLinkToIndexHtml (service, apiPath) {
+  const provider = (entity) => {
+    if (entity) return // avoid link on entity level, looks too messy
+    return { href: apiPath, name: 'Open API Preview', title: 'Show in Swagger UI' }
+  }
+  service.$linkProviders ? service.$linkProviders.push(provider) : service.$linkProviders = [provider]
+}
+
+/**
+ * @typedef {Object} CdsSwaggerOptions
+ * @property {string} basePath - the root path to mount the middleware on
+ * @property {string} apiPath - the root path for the services (useful if behind a reverse proxy)
+ * @property {boolean} diagram - whether to render the YUML diagram
+ * @property {string} odataVersion - the OData version used to compile the OpenAPI specs. Defaults to 4.01
+ */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@sap/cds-dk": ">=7",
         "swagger-ui-express": "^5"
       },
       "devDependencies": {
         "@sap/cds": "^7",
+        "@sap/cds-dk": "^7",
         "axios": "^1",
         "chai": "^4",
         "chai-as-promised": "^7",
@@ -26,7 +26,13 @@
       },
       "peerDependencies": {
         "@sap/cds": ">=7",
+        "@sap/cds-dk": ">=7",
         "express": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "@sap/cds-dk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -136,21 +142,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
-        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.5",
-        "@babel/parser": "^7.23.5",
+        "@babel/helpers": "^7.23.7",
+        "@babel/parser": "^7.23.6",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5",
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -189,12 +195,12 @@
       "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.5",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -204,14 +210,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -345,14 +351,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5"
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -444,9 +450,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -647,20 +653,20 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.5",
-        "@babel/types": "^7.23.5",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -691,9 +697,9 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
-      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
@@ -711,9 +717,9 @@
       "dev": true
     },
     "node_modules/@cap-js/cds-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/cds-types/-/cds-types-0.1.0.tgz",
-      "integrity": "sha512-aGIq8m3Ni2ScQtZWK4Rc/TnBJ4LjN4tdSmUatwUA5PSlCua8prheuDJ/k1xRL1F61Rsw0i6G5mZ2HbF2f2dbpA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/cds-types/-/cds-types-0.2.0.tgz",
+      "integrity": "sha512-s4iVwAjf+rRIUu6jaEooXFcJv16+sP5CTkreQPxDUyxLWWGlhvEr67TuIH0C6Cnp4PPIsYmBK3AVxSW2mNc2wg==",
       "dev": true,
       "peerDependencies": {
         "@sap/cds": ">=7"
@@ -1061,9 +1067,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1090,9 +1096,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.4.4.tgz",
-      "integrity": "sha512-dDTD3mLpTEhp1/5Pgvasf74avqeOP/OW27aE2tL3+ujYPYVvGgs5d3wtfdbchZscd9M9/jY/5dZKuQliNNHSAw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.5.0.tgz",
+      "integrity": "sha512-RzQPQShg0bWAv344sPF/qw/Y6uxA67N4JNIFwanXcvKdtigfPtiZDpEEWG+0Saalyd6PFI5WpYvF3Vbyb5qniA==",
       "dev": true,
       "dependencies": {
         "antlr4": "4.9.3"
@@ -1110,6 +1116,7 @@
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/@sap/cds-dk/-/cds-dk-7.5.1.tgz",
       "integrity": "sha512-kszcgVWJ5VNxXxz4+Yh6OZtoAWi6NiBu4KBkKLVcrr9QyL8pDf2XtJ0Xi3uK8cSpUvJxSuro8cqAR8vW19UMKA==",
+      "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
         "@sap/cds": "^7",
@@ -1137,6 +1144,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1144,6 +1152,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@cap-js/cds-types": {
       "version": "0.1.0",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "@sap/cds": ">=7"
@@ -1151,6 +1160,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
@@ -1164,6 +1174,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1171,6 +1182,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1192,6 +1204,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@eslint/js": {
       "version": "8.56.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1199,11 +1212,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.1",
@@ -1216,6 +1231,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1227,10 +1243,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.1",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@sap/cds-dk/node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1242,6 +1260,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1249,6 +1268,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1260,6 +1280,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -1269,6 +1290,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1281,6 +1303,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds": {
       "version": "7.5.2",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cap-js/cds-types": "<1",
@@ -1298,6 +1321,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-compiler": {
       "version": "4.5.0",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "antlr4": "4.9.3"
@@ -1313,6 +1337,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-fiori": {
       "version": "1.2.2",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "@sap/cds": ">=7",
@@ -1321,6 +1346,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-foss": {
       "version": "5.0.0",
+      "dev": true,
       "license": "See LICENSE in LICENSE",
       "dependencies": {
         "big.js": "^6.1.1",
@@ -1334,6 +1360,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-mtxs": {
       "version": "1.14.2",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sap/hdi-deploy": "^4",
@@ -1346,6 +1373,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/eslint-plugin-cds": {
       "version": "2.6.4",
+      "dev": true,
       "license": "See LICENSE file",
       "dependencies": {
         "@sap/cds": ">=5.6.0",
@@ -1360,6 +1388,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy": {
       "version": "4.9.1",
+      "dev": true,
       "license": "See LICENSE file",
       "dependencies": {
         "@sap/hana-client": "2.19.18",
@@ -1377,6 +1406,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/hana-client": {
       "version": "2.19.18",
+      "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN developer-license-3_1.txt",
       "dependencies": {
@@ -1388,6 +1418,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/hana-client/node_modules/debug": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -1395,10 +1426,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/hana-client/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/hdi": {
       "version": "4.5.2",
+      "dev": true,
       "license": "See LICENSE file",
       "dependencies": {
         "async": "3.2.3"
@@ -1421,6 +1454,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv": {
       "version": "3.4.0",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE file",
       "dependencies": {
         "debug": "4.3.3",
@@ -1433,6 +1467,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/assert-plus": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -1440,6 +1475,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/clone": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -1447,10 +1483,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/debug": {
       "version": "4.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -1466,6 +1504,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/extsprintf": {
       "version": "1.4.1",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -1473,10 +1512,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/node-cache": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "2.x"
@@ -1487,6 +1528,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv/node_modules/verror": {
       "version": "1.10.0",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -1499,10 +1541,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/async": {
       "version": "3.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -1513,6 +1557,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/dotenv": {
       "version": "10.0.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=10"
@@ -1520,6 +1565,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1530,6 +1576,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/handlebars": {
       "version": "4.7.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -1549,6 +1596,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/hdb": {
       "version": "0.19.3",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.4.18"
@@ -1559,6 +1607,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -1569,6 +1618,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -1576,6 +1626,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/micromatch": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.1",
@@ -1587,6 +1638,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1594,10 +1646,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/neo-async": {
       "version": "2.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/picomatch": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1608,10 +1662,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1619,6 +1675,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -1629,6 +1686,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/uglify-js": {
       "version": "3.17.4",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -1640,10 +1698,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi-deploy/node_modules/wordwrap": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1652,15 +1712,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/accepts": {
       "version": "1.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -1672,6 +1735,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/acorn": {
       "version": "8.11.3",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1682,6 +1746,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1689,6 +1754,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1700,6 +1766,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/agentkeepalive": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1711,6 +1778,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1723,6 +1791,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1737,6 +1806,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1744,6 +1814,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1757,6 +1828,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/antlr4": {
       "version": "4.9.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14"
@@ -1764,11 +1836,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/are-we-there-yet": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -1781,18 +1855,22 @@
     },
     "node_modules/@sap/cds-dk/node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/@sap/cds-dk/node_modules/array-flatten": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/axios": {
       "version": "1.6.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
@@ -1802,10 +1880,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1825,6 +1905,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/big.js": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -1836,6 +1917,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/bindings": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1844,6 +1926,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/bl": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1854,6 +1937,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/body-parser": {
       "version": "1.20.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -1876,6 +1960,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -1883,18 +1968,32 @@
     },
     "node_modules/@sap/cds-dk/node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@sap/cds-dk/node_modules/braces": {
+      "version": "3.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sap/cds-dk/node_modules/buffer": {
       "version": "5.7.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1918,6 +2017,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1925,6 +2025,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/cacache": {
       "version": "15.3.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -1953,6 +2054,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -1964,11 +2066,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/call-bind": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2",
@@ -1981,6 +2085,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1988,6 +2093,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2002,6 +2108,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -2010,6 +2117,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2018,6 +2126,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2028,10 +2137,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/color-support": {
       "version": "1.1.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -2040,6 +2151,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2050,15 +2162,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/content-disposition": {
       "version": "0.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -2069,6 +2184,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/content-type": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2076,6 +2192,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/cookie": {
       "version": "0.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2083,10 +2200,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/cookie-signature": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2099,6 +2218,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -2114,6 +2234,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/decompress-response": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2128,6 +2249,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2136,10 +2258,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/define-data-property": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.1",
@@ -2152,6 +2276,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2159,11 +2284,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/depd": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2171,6 +2298,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/destroy": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -2179,6 +2307,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/detect-libc": {
       "version": "2.0.2",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -2187,6 +2316,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -2197,15 +2327,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ee-first": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/encodeurl": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2213,6 +2346,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2221,6 +2355,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2232,6 +2367,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2240,6 +2376,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2248,15 +2385,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/escape-html": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2267,6 +2407,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/eslint": {
       "version": "8.56.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -2320,6 +2461,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/eslint-scope": {
       "version": "7.2.2",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2334,6 +2476,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2344,6 +2487,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/espree": {
       "version": "9.6.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -2359,6 +2503,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/esquery": {
       "version": "1.5.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2369,6 +2514,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -2379,6 +2525,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/estraverse": {
       "version": "5.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -2386,6 +2533,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2393,6 +2541,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/etag": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2400,6 +2549,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/expand-template": {
       "version": "2.0.3",
+      "dev": true,
       "license": "(MIT OR WTFPL)",
       "optional": true,
       "engines": {
@@ -2408,6 +2558,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/express": {
       "version": "4.18.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -2448,6 +2599,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/express/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2455,22 +2607,27 @@
     },
     "node_modules/@sap/cds-dk/node_modules/express/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/fastq": {
       "version": "1.16.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2478,6 +2635,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -2488,11 +2646,24 @@
     },
     "node_modules/@sap/cds-dk/node_modules/file-uri-to-path": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@sap/cds-dk/node_modules/fill-range": {
+      "version": "7.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sap/cds-dk/node_modules/finalhandler": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -2509,6 +2680,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2516,10 +2688,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/find-up": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -2534,6 +2708,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/flat-cache": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -2546,10 +2721,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/flatted": {
       "version": "3.2.9",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/follow-redirects": {
       "version": "1.15.4",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2568,6 +2745,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/form-data": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2580,6 +2758,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/forwarded": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2587,6 +2766,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/fresh": {
       "version": "0.5.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2594,11 +2774,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/fs-constants": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -2610,10 +2792,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2621,6 +2805,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/gauge": {
       "version": "4.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -2639,6 +2824,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/generic-pool": {
       "version": "3.9.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2646,6 +2832,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/get-intrinsic": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2",
@@ -2659,11 +2846,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/github-from-package": {
       "version": "0.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2682,6 +2871,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/glob-parent": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -2692,6 +2882,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/globals": {
       "version": "13.24.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2705,6 +2896,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/gopd": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -2715,15 +2907,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/graphemer": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2731,6 +2926,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/has-property-descriptors": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.2"
@@ -2741,6 +2937,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/has-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2751,6 +2948,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2761,11 +2959,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/hasown": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2776,11 +2976,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/http-cache-semantics": {
       "version": "4.1.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/http-errors": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -2795,6 +2997,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/http-proxy-agent": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2808,6 +3011,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2820,6 +3024,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2828,6 +3033,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -2838,6 +3044,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2857,6 +3064,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ignore": {
       "version": "5.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2864,6 +3072,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2878,6 +3087,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2885,6 +3095,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2893,11 +3104,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -2906,20 +3119,24 @@
     },
     "node_modules/@sap/cds-dk/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/ini": {
       "version": "1.3.8",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/ip": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -2927,6 +3144,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2934,6 +3152,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2942,6 +3161,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2952,11 +3172,21 @@
     },
     "node_modules/@sap/cds-dk/node_modules/is-lambda": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@sap/cds-dk/node_modules/is-number": {
+      "version": "7.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/@sap/cds-dk/node_modules/is-path-inside": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2964,10 +3194,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/js-yaml": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2978,18 +3210,22 @@
     },
     "node_modules/@sap/cds-dk/node_modules/json-buffer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/keyv": {
       "version": "4.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -2997,6 +3233,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -3008,10 +3245,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/livereload-js": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/locate-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -3025,10 +3264,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3055,6 +3296,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3066,11 +3308,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/media-typer": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3078,17 +3322,32 @@
     },
     "node_modules/@sap/cds-dk/node_modules/merge-descriptors": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/methods": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/@sap/cds-dk/node_modules/micromatch": {
+      "version": "4.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/@sap/cds-dk/node_modules/mime": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -3099,6 +3358,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3106,6 +3366,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3116,6 +3377,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/mimic-response": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3127,6 +3389,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3137,6 +3400,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -3145,6 +3409,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3156,6 +3421,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3167,6 +3433,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3183,6 +3450,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3194,6 +3462,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3205,6 +3474,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3216,11 +3486,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3233,11 +3505,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3249,15 +3523,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/mkdirp-classic": {
       "version": "0.5.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/mustache": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
@@ -3265,15 +3542,18 @@
     },
     "node_modules/@sap/cds-dk/node_modules/napi-build-utils": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/natural-compare": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/negotiator": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3281,6 +3561,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/node-abi": {
       "version": "3.54.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3292,11 +3573,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/node-addon-api": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3320,6 +3603,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/node-watch": {
       "version": "0.7.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3327,6 +3611,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/nopt": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3341,6 +3626,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/npmlog": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3355,6 +3641,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/object-inspect": {
       "version": "1.13.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3362,6 +3649,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/on-finished": {
       "version": "2.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -3372,6 +3660,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3379,6 +3668,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/optionator": {
       "version": "0.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
@@ -3394,6 +3684,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/p-limit": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -3407,6 +3698,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/p-locate": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -3420,6 +3712,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3434,6 +3727,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -3444,6 +3738,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/parseurl": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3451,6 +3746,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3458,6 +3754,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3465,6 +3762,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3472,10 +3770,23 @@
     },
     "node_modules/@sap/cds-dk/node_modules/path-to-regexp": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sap/cds-dk/node_modules/picomatch": {
+      "version": "2.3.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@sap/cds-dk/node_modules/pluralize": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3483,6 +3794,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/prebuild-install": {
       "version": "7.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3508,6 +3820,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -3515,11 +3828,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3532,6 +3847,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/proxy-addr": {
       "version": "2.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -3543,10 +3859,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/pump": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3556,6 +3874,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3563,6 +3882,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/qs": {
       "version": "6.11.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -3576,6 +3896,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3594,6 +3915,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/range-parser": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3601,6 +3923,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/raw-body": {
       "version": "2.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -3614,6 +3937,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
       "dependencies": {
@@ -3628,6 +3952,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3636,6 +3961,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/readable-stream": {
       "version": "3.6.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3649,6 +3975,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3656,6 +3983,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3664,6 +3992,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/reusify": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -3672,6 +4001,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -3685,6 +4015,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3706,6 +4037,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3724,14 +4056,17 @@
     },
     "node_modules/@sap/cds-dk/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/sax": {
       "version": "1.3.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/semver": {
       "version": "7.5.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3745,6 +4080,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -3755,10 +4091,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/send": {
       "version": "0.18.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -3781,6 +4119,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/send/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3788,14 +4127,17 @@
     },
     "node_modules/@sap/cds-dk/node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/send/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sap/cds-dk/node_modules/serve-static": {
       "version": "1.15.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
@@ -3809,11 +4151,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/set-function-length": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.1",
@@ -3827,10 +4171,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/setprototypeof": {
       "version": "1.2.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3841,6 +4187,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3848,6 +4195,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -3860,11 +4208,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/simple-concat": {
       "version": "1.0.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3884,6 +4234,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/simple-get": {
       "version": "4.0.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3908,6 +4259,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3917,6 +4269,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/socks": {
       "version": "2.7.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3930,6 +4283,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/socks-proxy-agent": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3943,6 +4297,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/sqlite3": {
       "version": "5.1.7",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -3966,6 +4321,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/ssri": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3977,6 +4333,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/statuses": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3984,6 +4341,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3992,6 +4350,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4005,6 +4364,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4015,6 +4375,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4025,6 +4386,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4035,6 +4397,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tar": {
       "version": "6.2.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4051,6 +4414,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tar-fs": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4062,11 +4426,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/tar-stream": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4082,6 +4448,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -4090,15 +4457,29 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sap/cds-dk/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/@sap/cds-dk/node_modules/toidentifier": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -4106,6 +4487,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4117,6 +4499,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -4127,6 +4510,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/type-fest": {
       "version": "0.20.2",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -4137,6 +4521,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/type-is": {
       "version": "1.6.18",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -4148,6 +4533,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/unique-filename": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4156,6 +4542,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/unique-slug": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4164,6 +4551,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/unpipe": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4171,6 +4559,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -4178,11 +4567,13 @@
     },
     "node_modules/@sap/cds-dk/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@sap/cds-dk/node_modules/utils-merge": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -4190,6 +4581,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/vary": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4197,6 +4589,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4210,6 +4603,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/wide-align": {
       "version": "1.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4218,10 +4612,12 @@
     },
     "node_modules/@sap/cds-dk/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@sap/cds-dk/node_modules/ws": {
       "version": "8.16.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4241,6 +4637,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/xml-js": {
       "version": "1.6.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": "^1.2.4"
@@ -4251,6 +4648,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/xmlbuilder": {
       "version": "15.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
@@ -4258,6 +4656,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/yaml": {
       "version": "2.3.4",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 14"
@@ -4265,6 +4664,7 @@
     },
     "node_modules/@sap/cds-dk/node_modules/yocto-queue": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4336,9 +4736,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -4355,9 +4755,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -4397,9 +4797,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
-      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -4797,9 +5197,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001566",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
+      "version": "1.0.30001579",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
       "dev": true,
       "funding": [
         {
@@ -4817,9 +5217,9 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.0.tgz",
-      "integrity": "sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -5158,9 +5558,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.601",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.601.tgz",
-      "integrity": "sha512-SpwUMDWe9tQu8JX5QCO1+p/hChAi9AE9UpoC3rcHVc+gdCGlbT3SGb5I1klgb952HRIyvt9wZhSz9bNBYz9swA==",
+      "version": "1.4.637",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.637.tgz",
+      "integrity": "sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5389,9 +5789,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true,
       "funding": [
         {
@@ -7257,14 +7657,15 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
       "dependencies": {
         "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7469,9 +7870,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.10.3.tgz",
-      "integrity": "sha512-fu3aozjxFWsmcO1vyt1q1Ji2kN7KlTd1vHy27E9WgPyXo9nrEzhQPqgxaAjbMsOmb8XFKNGo4Sa3Q+84Fh+pFw=="
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.0.tgz",
+      "integrity": "sha512-j0PIATqQSEFGOLmiJOJZj1X1Jt6bFIur3JpY7+ghliUnfZs0fpWDdHEkn9q7QUlBtKbkn6TepvSxTqnE8l3s0A=="
     },
     "node_modules/swagger-ui-express": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,15 +29,21 @@
     "index.js"
   ],
   "dependencies": {
-    "@sap/cds-dk": ">=7",
     "swagger-ui-express": "^5"
   },
   "peerDependencies": {
     "@sap/cds": ">=7",
+    "@sap/cds-dk": ">=7",
     "express": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "@sap/cds-dk": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@sap/cds": "^7",
+    "@sap/cds-dk": "^7",
     "axios": "^1",
     "chai": "^4",
     "chai-as-promised": "^7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "files": [
     "CHANGELOG.md",
+    "lib/",
+    "cds-plugin.js",
     "index.js"
   ],
   "dependencies": {
@@ -49,5 +51,48 @@
   "jest": {
     "testEnvironment": "node",
     "testTimeout": 10000
+  },
+  "cds": {
+    "schema": {
+      "cds": {
+        "swagger": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "basePath": {
+                  "type": "string",
+                  "description": "The root path to mount the middleware on",
+                  "default": "/$api-docs"
+                },
+                "apiPath": {
+                  "type": "string",
+                  "description": "The root path for the services (useful if behind a reverse proxy)"
+                },
+                "diagram": {
+                  "type": "boolean",
+                  "description": "Whether to render the YUML diagram",
+                  "default": true
+                },
+                "odataVersion": {
+                  "type": "string",
+                  "description": "the OData Version to compile the OpenAPI specs"
+                }
+              }
+            },
+            {
+              "type": "boolean",
+              "description": "Shortcut to disable Swagger UI"
+            }
+          ]
+        }
+      }
+    },
+    "swagger": {
+      "basePath": "/$api-docs",
+      "apiPath": "",
+      "diagram": true,
+      "odataVersion": ""
+    }
   }
 }

--- a/tests/app/.npmrc
+++ b/tests/app/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/tests/app/package.json
+++ b/tests/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-app",
+  "version": "1.0.0",
+  "devDependencies": {
+    "cds-swagger-ui-express": "file:../.."
+  },
+  "cds": {
+    "swagger": {
+      "basePath": "/$api-docs-plugin"
+    }
+   }
+}

--- a/tests/app/server.js
+++ b/tests/app/server.js
@@ -1,7 +1,4 @@
 const cds = require ('@sap/cds')
-const cds_swagger = require('../..')
-
-module.exports = cds.server
 
 let options = {}
 if (process.env.TEST_OPTIONS) {
@@ -12,4 +9,8 @@ if (process.env.TEST_OPTIONS_UI) {
   uiOptions = JSON.parse(process.env.TEST_OPTIONS_UI)
 }
 
-cds.on ('bootstrap', app => app.use(cds_swagger(options, uiOptions)))
+if (!process.env.TEST_AS_PLUGIN) {
+  // do not load index.js if running as plugin
+  const cds_swagger = require('../..')
+  cds.on ('bootstrap', app => app.use(cds_swagger(options, uiOptions)))
+}

--- a/tests/server-options.test.js
+++ b/tests/server-options.test.js
@@ -2,9 +2,10 @@ process.env.TEST_OPTIONS    = JSON.stringify({basePath:'/test-base', apiPath: '/
 process.env.TEST_OPTIONS_UI = JSON.stringify({customSiteTitle: 'My Custom Title'})
 
 const cds = require('@sap/cds')
-const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
 
 describe('with options', ()=>{
+  const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
+
   afterAll(() =>{ delete process.env.TEST_OPTIONS })
 
   test('Main HTML', async()=>{

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,7 +1,8 @@
-const cds = require('@sap/cds/lib')
-const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
+const cds = require('@sap/cds')
 
-describe('Swagger UI', ()=>{
+describe.only('Swagger UI', ()=>{
+
+  const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
 
   test('Service endpoint', async()=>{
     const { data } = await GET `/browse/$metadata`
@@ -27,6 +28,20 @@ describe('Swagger UI', ()=>{
 
     data  = (await GET `/$api-docs/admin/swagger-ui-init.js`).data
     expect (data ) .to.be.a('string').that.contains('AdminService')
+  })
+
+})
+
+describe('Swagger UI as plugin', ()=>{
+
+  beforeAll(()=> process.env.TEST_AS_PLUGIN = true)
+  afterAll(()=> delete process.env.TEST_AS_PLUGIN)
+
+  const { GET, expect } = cds.test.in(__dirname, 'app').run('serve', 'all')
+
+  test('Main HTML', async()=>{
+    const { data } = await GET `/$api-docs-plugin/browse`
+    expect (data) .match (/swagger/i)
   })
 
 })


### PR DESCRIPTION
- The middleware registers itself when loaded as a CAP plugin
- Declarative configuration through `package.json` / `cds-rc.json`
- Programmatic registration is still possible, but disables auto mode then
- Make `@sap/cds-dk` optional