### PR TITLE
Allow relative service root paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - The OpenAPI spec is no available for download on `.../openapi.json` and linked in the UI.
 
+### Changed
+
+- The default value for option `apiPath` is now `/`, allowing more flexible control over the root path where the CDS services are served.  Formerly, it was not possible to set root path _relative_  to the current host, like `abc.com/1234-appid/$api-docs/...`, `abc.com/5678-appid/$api-docs/...`.
+
 ## Version 0.9.0 - 2024-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can set the most prominent options in `package.json` or `.cdsrc.json`, as in
 "cds": {
   "swagger": {
     "basePath": "/$api-docs", // the root path to mount the middleware on
-    "apiPath": "", // the root path for the services (useful if behind a reverse proxy)
+    "apiPath": "/", // the root path for the services (useful if behind a reverse proxy)
     "diagram": true, // whether to render the YUML diagram
     "odataVersion": "4.0" // the OData Version to compile the OpenAPI specs. Defaults to 4.01
   }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -14,7 +14,7 @@ const { join } = require('path')
  * @returns {express.RequestHandler} - an express middleware
  */
 module.exports = (options={}, swaggerUiOptions={}) => {
-  options = Object.assign({ basePath: '/$api-docs', apiPath: '' }, options)
+  options = Object.assign({ basePath: '/$api-docs', apiPath: '/' }, options)
 
   const router = express.Router()
 
@@ -44,7 +44,7 @@ function toOpenApiDoc (service, options = {}) {
     cache[service.name] = openapi.compile(service.model, {
       service: service.name,
       'odata-version': options.odataVersion,
-      'openapi:url': join('/', options.apiPath, service.path),
+      'openapi:url': join(options.apiPath, service.path),
       'openapi:diagram': ('diagram' in options ? options.diagram : true),
       to: 'openapi' // workaround needed for cds-dk 7.4
     })

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     },
     "swagger": {
       "basePath": "/$api-docs",
-      "apiPath": "",
+      "apiPath": "/",
       "diagram": true,
       "odataVersion": ""
     }


### PR DESCRIPTION
The default value for option `apiPath` is now `/`, allowing more flexible control over the root path where the CDS services are served. Formerly, it was not possible to set root path _relative_  to the current host, like `abc.com/1234-appid/$api-docs/...`, `abc.com/5678-appid/$api-docs/...`.

Fixes https://github.com/chgeo/cds-swagger-ui-express/issues/151