### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -20,7 +20,7 @@ module.exports = (options={}, swaggerUiOptions={}) => {
 
   cds.on('serving', service => {
     const apiPath = options.basePath + service.path
-    const mount = apiPath.replace('$', '[\\$]')
+    const mount = apiPath.replace(/\$/g, '[\\$]')
     const openapiPath = apiPath + '/openapi.json'
     debug?.('serving Swagger UI for', { service: service.name, at: apiPath })
 


### PR DESCRIPTION
Fixes [https://github.com/chgeo/cds-swagger-ui-express/security/code-scanning/1](https://github.com/chgeo/cds-swagger-ui-express/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the `$` character in `apiPath` are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every `$` character in the string is replaced with `[\$]`.

- Modify the `replace` method on line 23 to use a regular expression with the global flag.
- No additional imports or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
